### PR TITLE
Centralize rate schedules, fix peak-change bug, add test suite

### DIFF
--- a/compare_power_costs.py
+++ b/compare_power_costs.py
@@ -14,13 +14,78 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
 from holidays.countries import US
 
 logger = logging.getLogger(__name__)
+
+SUMMER_MONTHS = frozenset({6, 7, 8, 9})
+PEAK_HOURS = frozenset({18, 19, 20, 21})
+
+
+@dataclass(frozen=True)
+class RateSchedule:
+    """Rocky Mountain Power rates in effect from ``effective_date`` onward.
+
+    All rate fields are base rates in USD/kWh (before fees and taxes).
+    The billed rate is ``base_rate * tax_fee_multiplier``.
+    """
+
+    effective_date: date
+    tax_fee_multiplier: float
+    # Schedule 1 block rates
+    block_summer_low: float
+    block_summer_high: float
+    block_winter_low: float
+    block_winter_high: float
+    # Time-of-Use rates
+    tou_summer_peak: float
+    tou_summer_off_peak: float
+    tou_winter_peak: float
+    tou_winter_off_peak: float
+
+
+# Newest-first. When RMP publishes a new schedule, prepend a new entry.
+RATE_SCHEDULES: list[RateSchedule] = [
+    RateSchedule(
+        effective_date=date(2025, 4, 25),
+        tax_fee_multiplier=1.3672,
+        block_summer_low=0.092814,
+        block_summer_high=0.119745,
+        block_winter_low=0.082136,
+        block_winter_high=0.105968,
+        tou_summer_peak=0.319683,
+        tou_summer_off_peak=0.071041,
+        tou_winter_peak=0.282905,
+        tou_winter_off_peak=0.062868,
+    ),
+]
+
+
+def get_rate_schedule(usage_date: date) -> RateSchedule:
+    """Return the rate schedule to apply for ``usage_date``.
+
+    Picks the most recent schedule whose ``effective_date`` is on or before ``usage_date``.
+    If ``usage_date`` predates every known schedule, falls back to the earliest — this lets
+    historical usage data be scored against current rates ("what would this have cost today?").
+
+    Args:
+        usage_date: the billing date to look up
+
+    Returns:
+        a ``RateSchedule``
+    """
+    schedules_newest_first = sorted(
+        RATE_SCHEDULES, key=lambda s: s.effective_date, reverse=True
+    )
+    for schedule in schedules_newest_first:
+        if usage_date >= schedule.effective_date:
+            return schedule
+    return schedules_newest_first[-1]
 
 
 class RockyMountainPowerHolidays(US):
@@ -215,13 +280,13 @@ def calculate_block_cost(
     Returns:
         float: cost in USD
     """
-    month_index = date_object.month
-    summer_months = [6, 7, 8, 9]
-    low_rate = 0.1122963392
-    high_rate = 0.1448794496
-    if month_index in summer_months:
-        low_rate = 0.1268953008
-        high_rate = 0.163715364
+    schedule = get_rate_schedule(date_object.date())
+    if date_object.month in SUMMER_MONTHS:
+        low_rate = schedule.block_summer_low * schedule.tax_fee_multiplier
+        high_rate = schedule.block_summer_high * schedule.tax_fee_multiplier
+    else:
+        low_rate = schedule.block_winter_low * schedule.tax_fee_multiplier
+        high_rate = schedule.block_winter_high * schedule.tax_fee_multiplier
 
     if usage_sum + usage <= 400:  # Still in the first 400 kWh block
         block_cost = usage * low_rate
@@ -251,15 +316,12 @@ def is_peak_hour(
     Returns:
         bool: True if peak hour, else false
     """
-    usage_hour = date_object.hour
-
-    peak_hours = [18, 19, 20, 21]
-
-    is_weekday = date_object.weekday() in range(0, 5)
+    is_weekday = date_object.weekday() < 5
     is_holiday = date_object in rmp_holidays
     peak_day = is_weekday and not is_holiday
-    is_peak = peak_day and usage_hour in peak_hours
+    is_peak = peak_day and date_object.hour in PEAK_HOURS
     return is_peak
+
 
 def get_tou_rates(date_object: datetime) -> tuple[float, float]:
     """Given a day/hour, return the peak, and off-peak time of usage rates for that day
@@ -284,14 +346,13 @@ def get_tou_rates(date_object: datetime) -> tuple[float, float]:
     Returns:
         tuple[float, float]: peak rate for the given day, and off-peak rate for the given day
     """
-    usage_month = date_object.month
-    summer_months = [6, 7, 8, 9]
-    tax_fee_rate = 1.3672
-    peak_rate = 0.282905 * tax_fee_rate # 0.386787716
-    off_peak_rate = 0.062868 * tax_fee_rate # 0.0859531296
-    if usage_month in summer_months:
-        peak_rate = 0.319683 * tax_fee_rate # 0.4370705976
-        off_peak_rate = 0.071041 * tax_fee_rate # 0.0971272552
+    schedule = get_rate_schedule(date_object.date())
+    if date_object.month in SUMMER_MONTHS:
+        peak_rate = schedule.tou_summer_peak * schedule.tax_fee_multiplier
+        off_peak_rate = schedule.tou_summer_off_peak * schedule.tax_fee_multiplier
+    else:
+        peak_rate = schedule.tou_winter_peak * schedule.tax_fee_multiplier
+        off_peak_rate = schedule.tou_winter_off_peak * schedule.tax_fee_multiplier
     return peak_rate, off_peak_rate
 
 
@@ -300,49 +361,49 @@ def calculate_ev_cost(
 ) -> tuple[float, bool]:
     """Calculate the day's EV cost
 
-    Definition taken from:
-    https://www.rockymountainpower.net/content/dam/pcorp/documents/en/rockymountainpower/rates-regulation/utah/rates/001_Residential_Service.pdf
+     Definition taken from:
+     https://www.rockymountainpower.net/content/dam/pcorp/documents/en/rockymountainpower/rates-regulation/utah/rates/001_Residential_Service.pdf
 
-   Energy Charge:
-    Billing Months - June through September inclusive
-        31.9683¢ per kWh for all On-Peak kWh
-        7.1041¢ per kWh for all Off-Peak kWh
+    Energy Charge:
+     Billing Months - June through September inclusive
+         31.9683¢ per kWh for all On-Peak kWh
+         7.1041¢ per kWh for all Off-Peak kWh
 
-    Billing Months - October through May inclusive
-        28.2905¢ per kWh for all On-Peak kWh
-        6.2868¢ per kWh for all Off-Peak kWh
+     Billing Months - October through May inclusive
+         28.2905¢ per kWh for all On-Peak kWh
+         6.2868¢ per kWh for all Off-Peak kWh
 
-    Prices get adjusted as follows:
-        - add 23.84% fees to base price
-        - after fees are added, add another 10.4% for taxes
-        - effective total increase is 36.72%
+     Prices get adjusted as follows:
+         - add 23.84% fees to base price
+         - after fees are added, add another 10.4% for taxes
+         - effective total increase is 36.72%
 
-    TIME PERIODS:
-        On-Peak: 6:00 p.m. to 10:00 p.m. Monday thru Friday, except holidays.
-        Off-Peak: All other times.
+     TIME PERIODS:
+         On-Peak: 6:00 p.m. to 10:00 p.m. Monday thru Friday, except holidays.
+         Off-Peak: All other times.
 
-    Holidays include only
-        - New Year's Day
-        - President's Day
-        - Memorial Day
-        - Independence Day
-        - Pioneer Day
-        - Labor Day
-        - Thanksgiving Day
-        - Christmas Day.
-    When a holiday falls on a Saturday or Sunday, the Friday before the holiday (if the holiday
-    falls on a Saturday) or the Monday following the holiday (if the holiday falls on a Sunday)
-    will be considered a holiday and consequently Off-Peak.
+     Holidays include only
+         - New Year's Day
+         - President's Day
+         - Memorial Day
+         - Independence Day
+         - Pioneer Day
+         - Labor Day
+         - Thanksgiving Day
+         - Christmas Day.
+     When a holiday falls on a Saturday or Sunday, the Friday before the holiday (if the holiday
+     falls on a Saturday) or the Monday following the holiday (if the holiday falls on a Sunday)
+     will be considered a holiday and consequently Off-Peak.
 
-    Args:
-        date_object: object representing the day/hour in question
-        usage: usage
-        rmp_holidays: Holiday object defining the RMP holidays
+     Args:
+         date_object: object representing the day/hour in question
+         usage: usage
+         rmp_holidays: Holiday object defining the RMP holidays
 
-    Returns:
-        Tuple containing:
-            float: usage cost in USD
-            bool: True if peak hour, else false
+     Returns:
+         Tuple containing:
+             float: usage cost in USD
+             bool: True if peak hour, else false
     """
     peak_hour = is_peak_hour(date_object=date_object, rmp_holidays=rmp_holidays)
     peak_rate, off_peak_rate = get_tou_rates(date_object=date_object)

--- a/current_peak_status.py
+++ b/current_peak_status.py
@@ -56,15 +56,11 @@ def find_next_peak_change(
         timedelta: time until next change in peak status
     """
     initial_peak = is_peak_hour(date_object=date_object, rmp_holidays=rmp_holidays)
-    # Ensure start_datetime is at the start of the hour
-    if (
-        date_object.minute != 0
-        or date_object.second != 0
-        or date_object.microsecond != 0
-    ):
-        iter_datetime = date_object.replace(
-            minute=0, second=0, microsecond=0
-        ) + timedelta(hours=1)
+    # Start at the next hour boundary. If already exactly on an hour, advance one hour
+    # to skip re-testing the current hour (which is always same as initial_peak).
+    iter_datetime = date_object.replace(minute=0, second=0, microsecond=0) + timedelta(
+        hours=1
+    )
 
     while (
         is_peak_hour(date_object=iter_datetime, rmp_holidays=rmp_holidays)

--- a/makefile
+++ b/makefile
@@ -21,5 +21,9 @@ format:
 	black .
 	isort .
 
+.PHONY: test
+test:
+	pytest tests/
+
 .PHONY: ready
-ready: format lint
+ready: format lint test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v"
+
+[tool.isort]
+profile = "black"

--- a/realease_notes.md
+++ b/realease_notes.md
@@ -1,0 +1,177 @@
+# Release Notes
+
+## Summary
+
+Three fixes to `compare_power_costs`:
+
+1. **Bugfix** — `current_peak_status.py` crashed with `UnboundLocalError` when called at an exact hour boundary.
+2. **Refactor** — Rate tables centralized behind a date-keyed lookup, so future rate-schedule changes (e.g. the Dec 2025 TOU update) are a one-line edit.
+3. **Tests** — Added a pytest suite covering rate lookup, TOU rates, block-pricing boundaries, peak-hour classification, and a regression test for fix #1.
+
+No behavior change on existing sample data — output of `./compare_power_costs.py ./2024-09` is byte-identical to the pre-change version.
+
+---
+
+## 1. Fix `UnboundLocalError` in `find_next_peak_change`
+
+### Problem
+
+In [current_peak_status.py](current_peak_status.py), `find_next_peak_change` crashed whenever it was called with a `datetime` whose minute, second, and microsecond were all zero. The variable `iter_datetime` was only assigned inside an `if` that ran for *non-boundary* times:
+
+```python
+# before
+if (
+    date_object.minute != 0
+    or date_object.second != 0
+    or date_object.microsecond != 0
+):
+    iter_datetime = date_object.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+
+while is_peak_hour(iter_datetime, ...) == initial_peak:  # UnboundLocalError at :00:00.000
+    iter_datetime += timedelta(hours=1)
+```
+
+This is easy to hit in practice — any automation that polls on hour boundaries (cron, Home Assistant templates) would trigger it.
+
+### Fix
+
+Always initialize `iter_datetime` to the next hour boundary. If already on the boundary, advancing one hour is correct anyway because the current hour is by definition the same peak state as `initial_peak` — no information is lost.
+
+```python
+# after
+iter_datetime = date_object.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+```
+
+### Test coverage
+
+- `test_find_next_peak_change_on_exact_hour_boundary_does_not_crash` — regression guard for the exact failure mode.
+- `test_find_next_peak_change_mid_hour` — unchanged behavior for non-boundary inputs.
+- `test_find_next_peak_change_during_peak` — verifies the peak → off-peak transition.
+
+---
+
+## 2. Centralize rates with effective-date lookup
+
+### Problem
+
+Rate numbers were scattered as magic literals across two functions:
+
+- [calculate_block_cost](compare_power_costs.py) hardcoded post-tax rates (e.g. `0.1122963392`).
+- [get_tou_rates](compare_power_costs.py) hardcoded base rates and multiplied by `1.3672` inline.
+
+Two issues:
+
+1. **Maintenance cost.** Rocky Mountain Power has already signalled a TOU change coming 2025-12-01 (see [README.md](README.md)). With rates inline, updating them means editing multiple functions and keeping the tax-multiplier handling in sync.
+2. **No notion of time.** Every analysis silently used whichever rate was hardcoded, regardless of the usage date. Historical comparisons against *older* rates were not expressible.
+
+### Change
+
+Introduced a dataclass and a module-level list of schedules:
+
+```python
+@dataclass(frozen=True)
+class RateSchedule:
+    effective_date: date
+    tax_fee_multiplier: float
+    block_summer_low: float
+    block_summer_high: float
+    block_winter_low: float
+    block_winter_high: float
+    tou_summer_peak: float
+    tou_summer_off_peak: float
+    tou_winter_peak: float
+    tou_winter_off_peak: float
+
+RATE_SCHEDULES: list[RateSchedule] = [
+    RateSchedule(
+        effective_date=date(2025, 4, 25),
+        tax_fee_multiplier=1.3672,
+        block_summer_low=0.092814,
+        # ... base rates only; multiplier applied at lookup time
+    ),
+]
+
+def get_rate_schedule(usage_date: date) -> RateSchedule: ...
+```
+
+`calculate_block_cost` and `get_tou_rates` now call `get_rate_schedule(date_object.date())` and read from the returned schedule. Both functions lost their rate literals entirely.
+
+Also promoted `summer_months` and `peak_hours` from per-call `list` rebuilds to module-level `frozenset` constants (`SUMMER_MONTHS`, `PEAK_HOURS`).
+
+### When `usage_date` predates every known schedule
+
+The original script's semantics were "score these usages against the current rates" — it applied the April 2025 rates to the 2024 sample data in the repo without issue. To preserve that, `get_rate_schedule` falls back to the earliest known schedule when the usage date predates every `effective_date`. A strict "raise ValueError" mode would have broken the sample-data workflow documented in the README.
+
+### How to add a future rate change
+
+When RMP publishes the Dec 2025 TOU rates, prepend a new entry:
+
+```python
+RATE_SCHEDULES: list[RateSchedule] = [
+    RateSchedule(effective_date=date(2025, 12, 1), ...),   # new
+    RateSchedule(effective_date=date(2025, 4, 25), ...),   # existing
+]
+```
+
+No other code changes required. Cross-boundary analyses (usage spanning Nov–Dec 2025) will automatically apply the right rates to each hour.
+
+### Numerical equivalence
+
+Verified by running `./compare_power_costs.py ./2024-09` before and after — output matches exactly (`block_cost: 151.903`, `ev_cost: 144.638`, etc.). The base rates in the schedule, times `1.3672`, produce the same post-tax values that were previously hardcoded:
+
+| Rate               | Base × 1.3672          | Old hardcoded value |
+|--------------------|------------------------|---------------------|
+| Block summer low   | 0.092814 × 1.3672      | 0.1268953008        |
+| Block summer high  | 0.119745 × 1.3672      | 0.163715364         |
+| Block winter low   | 0.082136 × 1.3672      | 0.1122963392        |
+| Block winter high  | 0.105968 × 1.3672      | 0.1448794496        |
+
+---
+
+## 3. Pytest suite
+
+### Scope
+
+Added [tests/test_compare_power_costs.py](tests/test_compare_power_costs.py) with 38 tests grouped by module area:
+
+- **`get_rate_schedule`** — active-schedule lookup, historical fallback, most-recent wins when multiple schedules overlap.
+- **`get_tou_rates`** — winter/summer values to 9-digit precision; parametrized over all 12 months to confirm the summer-month set.
+- **`calculate_block_cost`** — entirely-low, entirely-high, split at the 400 kWh boundary, exact-boundary edge case, and summer rate selection.
+- **`is_peak_hour`** — all four peak hours (18–21), a sampling of off-peak hours, weekend exclusion, holiday exclusion on a weekday, and a Thanksgiving regression guard (recent bugfix per git log).
+- **`find_next_peak_change`** — the hour-boundary regression test, mid-hour, and during-peak cases.
+
+### Running
+
+```bash
+make test      # new target
+# or
+pytest tests/
+```
+
+### Dev dependency
+
+Added `pytest` to [requirements-dev.txt](requirements-dev.txt).
+
+---
+
+## Files changed
+
+| File                                                         | Change                                          |
+|--------------------------------------------------------------|-------------------------------------------------|
+| [compare_power_costs.py](compare_power_costs.py)             | Rate dataclass + lookup; constants hoisted      |
+| [current_peak_status.py](current_peak_status.py)             | `UnboundLocalError` fix                         |
+| [tests/test_compare_power_costs.py](tests/test_compare_power_costs.py) | New — 38 tests                        |
+| [tests/__init__.py](tests/__init__.py)                       | New — empty package marker                      |
+| [requirements-dev.txt](requirements-dev.txt)                 | Added `pytest`                                  |
+| [makefile](makefile)                                         | New `test` target; added to `ready`             |
+
+## Verification
+
+```text
+$ make test
+pytest tests/
+======================== 38 passed, 1 warning in 0.08s =========================
+
+$ ./compare_power_costs.py ./2024-09
+# Output matches README example exactly (block_cost 151.903, ev_cost 144.638, …)
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 ruff
 black
 isort
+pytest

--- a/tests/test_compare_power_costs.py
+++ b/tests/test_compare_power_costs.py
@@ -1,0 +1,256 @@
+"""Unit tests for compare_power_costs rate and peak-hour logic."""
+
+from datetime import date, datetime, timedelta
+
+import pytest
+
+import compare_power_costs
+from compare_power_costs import (
+    RATE_SCHEDULES,
+    RateSchedule,
+    RockyMountainPowerHolidays,
+    calculate_block_cost,
+    get_rate_schedule,
+    get_tou_rates,
+    is_peak_hour,
+)
+from current_peak_status import find_next_peak_change
+
+# A Tuesday in January (winter, non-holiday) and a Tuesday in July (summer, non-holiday).
+# 2025-01-21 and 2025-07-15 are both Tuesdays; neither is an RMP holiday.
+WINTER_WEEKDAY = datetime(2025, 1, 21, 12, 0)
+SUMMER_WEEKDAY = datetime(2025, 7, 15, 12, 0)
+
+
+@pytest.fixture
+def rmp_holidays():
+    """Provide a fresh RockyMountainPowerHolidays instance for peak-hour tests."""
+    return RockyMountainPowerHolidays()
+
+
+# ---------------------------------------------------------------------------
+# get_rate_schedule
+# ---------------------------------------------------------------------------
+
+
+def test_get_rate_schedule_returns_active_schedule():
+    """Lookup for a date inside a known schedule returns that schedule."""
+    schedule = get_rate_schedule(date(2025, 6, 1))
+    assert schedule.effective_date <= date(2025, 6, 1)
+
+
+def test_get_rate_schedule_falls_back_for_historical_date():
+    """Dates predating every schedule fall back to the earliest known schedule.
+
+    Preserves the script's original semantics of scoring historical usage data
+    against current rates (the repo ships 2024 sample data but the known
+    schedule starts 2025-04-25).
+    """
+    earliest = min(RATE_SCHEDULES, key=lambda s: s.effective_date)
+    assert get_rate_schedule(date(2020, 1, 1)) is earliest
+
+
+def test_get_rate_schedule_picks_most_recent_when_multiple():
+    """With overlapping schedules, lookup returns the most recent one in effect.
+
+    Monkey-patches RATE_SCHEDULES with two synthetic schedules to verify the
+    boundary behavior — important because the Dec 2025 TOU change will add a
+    second real entry.
+    """
+    older = RateSchedule(
+        effective_date=date(2020, 1, 1),
+        tax_fee_multiplier=1.0,
+        block_summer_low=0.1,
+        block_summer_high=0.2,
+        block_winter_low=0.1,
+        block_winter_high=0.2,
+        tou_summer_peak=0.3,
+        tou_summer_off_peak=0.05,
+        tou_winter_peak=0.25,
+        tou_winter_off_peak=0.04,
+    )
+    newer = RateSchedule(
+        effective_date=date(2024, 1, 1),
+        tax_fee_multiplier=1.0,
+        block_summer_low=0.2,
+        block_summer_high=0.3,
+        block_winter_low=0.2,
+        block_winter_high=0.3,
+        tou_summer_peak=0.4,
+        tou_summer_off_peak=0.06,
+        tou_winter_peak=0.35,
+        tou_winter_off_peak=0.05,
+    )
+    original = compare_power_costs.RATE_SCHEDULES
+    compare_power_costs.RATE_SCHEDULES = [older, newer]
+    try:
+        assert compare_power_costs.get_rate_schedule(date(2024, 6, 1)) is newer
+        assert compare_power_costs.get_rate_schedule(date(2023, 6, 1)) is older
+    finally:
+        compare_power_costs.RATE_SCHEDULES = original
+
+
+# ---------------------------------------------------------------------------
+# get_tou_rates
+# ---------------------------------------------------------------------------
+
+
+def test_get_tou_rates_winter():
+    """Winter-month TOU lookup returns the Oct-May billed rates.
+
+    Verifies the exact post-tax values (base * 1.3672) to 9-digit precision —
+    this is a guard against accidental drift when rate data is refactored.
+    """
+    peak, off_peak = get_tou_rates(WINTER_WEEKDAY)
+    assert peak == pytest.approx(0.386787716, rel=1e-9)
+    assert off_peak == pytest.approx(0.0859531296, rel=1e-9)
+
+
+def test_get_tou_rates_summer():
+    """Summer-month TOU lookup returns the Jun-Sep billed rates.
+
+    Verifies the exact post-tax values (base * 1.3672) to 9-digit precision.
+    """
+    peak, off_peak = get_tou_rates(SUMMER_WEEKDAY)
+    assert peak == pytest.approx(0.4370705976, rel=1e-9)
+    assert off_peak == pytest.approx(0.0971272552, rel=1e-9)
+
+
+@pytest.mark.parametrize("month", [6, 7, 8, 9])
+def test_summer_months_use_summer_rates(month):
+    """Months 6-9 are classified as summer and use the summer peak rate."""
+    peak, _ = get_tou_rates(datetime(2025, month, 15, 12, 0))
+    assert peak == pytest.approx(0.4370705976, rel=1e-9)
+
+
+@pytest.mark.parametrize("month", [1, 2, 3, 4, 5, 10, 11, 12])
+def test_winter_months_use_winter_rates(month):
+    """All non-summer months use the winter peak rate."""
+    peak, _ = get_tou_rates(datetime(2025, month, 15, 12, 0))
+    assert peak == pytest.approx(0.386787716, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# calculate_block_cost — boundary handling around 400 kWh
+# ---------------------------------------------------------------------------
+
+
+def test_block_cost_entirely_in_low_block_winter():
+    """Usage entirely under the 400 kWh monthly threshold bills at the low rate."""
+    cost = calculate_block_cost(WINTER_WEEKDAY, usage=100, usage_sum=0)
+    assert cost == pytest.approx(100 * 0.1122963392, rel=1e-9)
+
+
+def test_block_cost_entirely_in_high_block_winter():
+    """Usage added on top of a running sum already past 400 kWh bills at the high rate."""
+    cost = calculate_block_cost(WINTER_WEEKDAY, usage=100, usage_sum=500)
+    assert cost == pytest.approx(100 * 0.1448794496, rel=1e-9)
+
+
+def test_block_cost_splits_across_400_boundary_winter():
+    """Usage that straddles the 400 kWh threshold is split between the two rates.
+
+    With 300 kWh already used, adding 200 kWh should bill the first 100 at the
+    low rate and the remaining 100 at the high rate.
+    """
+    cost = calculate_block_cost(WINTER_WEEKDAY, usage=200, usage_sum=300)
+    expected = 100 * 0.1122963392 + 100 * 0.1448794496
+    assert cost == pytest.approx(expected, rel=1e-9)
+
+
+def test_block_cost_exactly_at_400_boundary_is_all_low():
+    """Usage that lands exactly on 400 kWh (not past it) stays in the low block.
+
+    Pins the inclusive ``usage_sum + usage <= 400`` behavior of the current
+    implementation — any change to a strict ``<`` would fail this test.
+    """
+    cost = calculate_block_cost(WINTER_WEEKDAY, usage=100, usage_sum=300)
+    assert cost == pytest.approx(100 * 0.1122963392, rel=1e-9)
+
+
+def test_block_cost_uses_summer_rates_in_summer():
+    """Block-cost lookup selects summer rates for summer-month dates."""
+    cost = calculate_block_cost(SUMMER_WEEKDAY, usage=100, usage_sum=0)
+    assert cost == pytest.approx(100 * 0.1268953008, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# is_peak_hour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hour", [18, 19, 20, 21])
+def test_peak_hours_on_weekday(rmp_holidays, hour):
+    """Hours 18-21 on a non-holiday weekday are classified as peak.
+
+    Uses 2025-01-21, a Tuesday with no RMP holiday.
+    """
+    assert is_peak_hour(datetime(2025, 1, 21, hour, 0), rmp_holidays) is True
+
+
+@pytest.mark.parametrize("hour", [0, 6, 12, 17, 22, 23])
+def test_off_peak_hours_on_weekday(rmp_holidays, hour):
+    """Hours outside 18-21 on a weekday are classified as off-peak.
+
+    Samples the hour just before peak (17) and just after (22) to guard the
+    boundary, plus a spread of daytime and overnight hours.
+    """
+    assert is_peak_hour(datetime(2025, 1, 21, hour, 0), rmp_holidays) is False
+
+
+def test_weekend_is_never_peak(rmp_holidays):
+    """Saturdays and Sundays are always off-peak, even during the 18-21 window."""
+    assert is_peak_hour(datetime(2025, 1, 25, 19, 0), rmp_holidays) is False
+    assert is_peak_hour(datetime(2025, 1, 26, 19, 0), rmp_holidays) is False
+
+
+def test_holiday_weekday_is_off_peak(rmp_holidays):
+    """RMP holidays that fall on a weekday are off-peak.
+
+    2025-01-01 is a Wednesday and New Year's Day — the 19:00 hour would be
+    peak on an ordinary Wednesday but must be off-peak on the holiday.
+    """
+    assert is_peak_hour(datetime(2025, 1, 1, 19, 0), rmp_holidays) is False
+
+
+def test_thanksgiving_is_off_peak(rmp_holidays):
+    """Thanksgiving is recognized as a holiday.
+
+    Regression guard for the prior bug (see commit a28499b) where Thanksgiving
+    was misclassified as a peak weekday.
+    """
+    assert is_peak_hour(datetime(2025, 11, 27, 19, 0), rmp_holidays) is False
+
+
+# ---------------------------------------------------------------------------
+# find_next_peak_change — UnboundLocalError regression test
+# ---------------------------------------------------------------------------
+
+
+def test_find_next_peak_change_on_exact_hour_boundary_does_not_crash(rmp_holidays):
+    """Calling at an exact hour boundary no longer raises UnboundLocalError.
+
+    Previously ``iter_datetime`` was only assigned inside an if-branch that
+    skipped when minute/second/microsecond were all zero. 14:00 on a Tuesday
+    is off-peak; the next change is at 18:00, a 4-hour delta.
+    """
+    delta = find_next_peak_change(datetime(2025, 1, 21, 14, 0, 0), rmp_holidays)
+    assert delta == timedelta(hours=4)
+
+
+def test_find_next_peak_change_mid_hour(rmp_holidays):
+    """Non-boundary input returns the delta to the next transition.
+
+    14:30 on a Tuesday is off-peak; peak starts at 18:00, a 3h30m delta.
+    """
+    delta = find_next_peak_change(datetime(2025, 1, 21, 14, 30, 0), rmp_holidays)
+    assert delta == timedelta(hours=3, minutes=30)
+
+
+def test_find_next_peak_change_during_peak(rmp_holidays):
+    """During a peak window, the delta is the remaining peak time.
+
+    19:00 on a Tuesday is peak; peak ends at 22:00, a 3-hour delta.
+    """
+    delta = find_next_peak_change(datetime(2025, 1, 21, 19, 0, 0), rmp_holidays)
+    assert delta == timedelta(hours=3)


### PR DESCRIPTION
## Summary
- Replace inline rate literals with a date-keyed `RateSchedule` lookup so future rate-schedule changes (e.g. the Dec 2025 TOU update) are a one-line edit. Output on the repo's sample data is byte-identical.
- Fix `UnboundLocalError` in `find_next_peak_change` when called at an exact hour boundary (common for cron / Home Assistant polling).
- Add pytest suite (38 tests) covering rate lookup, TOU rates, block-cost boundaries, peak-hour classification, and a regression test for the bug above.
- Add `pyproject.toml` with verbose pytest output and isort/black compatibility. Wire `make test`; add `pytest` to dev requirements.

See `realease_notes.md` for a full per-change writeup (problem → fix → tests) and a rate-equivalence table demonstrating no numeric drift.

## Test plan
- [x] `make lint` passes (ruff + black + isort)
- [x] `make test` — 38 passed
- [x] `./compare_power_costs.py ./2024-09` produces output identical to the README example
- [x] `find_next_peak_change` no longer crashes at exact hour boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)